### PR TITLE
Remove deprecated tap for Homebrew

### DIFF
--- a/mac
+++ b/mac
@@ -121,7 +121,6 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
-tap "homebrew/services"
 
 # Unix
 brew "git"


### PR DESCRIPTION
`homebrew/services` were deprecated and now it is part of the brew itself: https://github.com/Homebrew/homebrew-services/blob/master/README.md