### PR TITLE
chore: post onboarding fixes, adding nvm

### DIFF
--- a/mac
+++ b/mac
@@ -151,14 +151,12 @@ brew "pyenv-virtualenv"
 # Git large files
 brew "git-lfs"
 
-# Node Version Manager
-brew "nvm"
-
 EOF
 
 append_to_zshrc 'export PYENV_ROOT="$HOME/.pyenv"'
 append_to_zshrc '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
 append_to_zshrc 'eval "$(pyenv init - zsh)"'
+append_to_zshrc 'eval "$(pyenv virtualenv-init -)"'
 
 if [ -w "$HOME/.zshrc.local" ]; then
   source "$HOME/.zshrc.local"
@@ -166,12 +164,12 @@ else
   source "$HOME/.zshrc"
 fi
 
-pyenv global 3.12.9
-
 ## poetry (https://python-poetry.org/docs/#installing-with-the-official-installer)
 append_to_zshrc 'export PATH="$HOME/.local/bin:$PATH"'
-curl -sSL https://install.python-poetry.org | python3 -
-poetry self update 1.8.3
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
+
+# Node Version Manager
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 
 # Open docker
 open /Applications/Docker.app

--- a/mac
+++ b/mac
@@ -148,25 +148,30 @@ brew "go-task"
 brew "pyenv"
 brew "pyenv-virtualenv"
 
-# Yarn
-brew "yarn"
-
 # Git large files
 brew "git-lfs"
 
-# Node
-brew "node"
+# Node Version Manager
+brew "nvm"
 
 EOF
+
+append_to_zshrc 'export PYENV_ROOT="$HOME/.pyenv"'
+append_to_zshrc '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+append_to_zshrc 'eval "$(pyenv init - zsh)"'
+
+if [ -w "$HOME/.zshrc.local" ]; then
+  source "$HOME/.zshrc.local"
+else
+  source "$HOME/.zshrc"
+fi
+
+pyenv global 3.12.9
 
 ## poetry (https://python-poetry.org/docs/#installing-with-the-official-installer)
 append_to_zshrc 'export PATH="$HOME/.local/bin:$PATH"'
 curl -sSL https://install.python-poetry.org | python3 -
 poetry self update 1.8.3
-
-append_to_zshrc 'export PYENV_ROOT="$HOME/.pyenv"'
-append_to_zshrc '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-append_to_zshrc 'eval "$(pyenv init - zsh)"'
 
 # Open docker
 open /Applications/Docker.app


### PR DESCRIPTION
Some post onboarding fixes to the script:
- Adding `nvm`
- Removing `node` and `yarn`
- Moving `poetry` install after `pyenv` install
- Sourcing `zsh` env before trying to install `poetry`
- Adding auto virtualenv init