### PR TITLE
feat(onboarding): adding missing deps kubectx and postgresql

### DIFF
--- a/mac
+++ b/mac
@@ -133,8 +133,12 @@ cask "google-chrome"
 # Google Cloud
 cask "google-cloud-sdk"
 
-# Kubernetes ClI
+# Kubernetes CLI
 brew "kubernetes-cli"
+brew "kubectx"
+
+# PostgresQL used mostly with tools
+brew "postgresql@14"
 
 # Programming language prerequisites
 brew "libyaml" # should come after openssl


### PR DESCRIPTION
Adding missing dependencies `kubectx` and `postgresql` to the onboarding scripts.

- `kubectx` is used to switch contexts to target `dev`, `dev2` or `prod`
- `postgresql` is used mostly for the tooling to run the backend unit tests
  locally
